### PR TITLE
Create Quote block

### DIFF
--- a/wp-content/themes/movies/src/Blocks/Blocks.php
+++ b/wp-content/themes/movies/src/Blocks/Blocks.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 namespace Movies\Blocks;
 
 use MoviesVendor\EightshiftLibs\Blocks\AbstractBlocks;
+use Movies\CustomPostType\MoviesPostType;
+use WP_Block_Editor_Context;
 
 /**
  * Class Blocks
@@ -46,5 +48,66 @@ class Blocks extends AbstractBlocks
 
 		// Output inline css variables.
 		\add_action('wp_footer', [$this, 'outputCssVariablesInline']);
+
+		// Only allow custom built blocks and limit blocks for Movies CPT.
+		\add_filter('allowed_block_types_all', [$this, 'allowOnlyCustomBlocks'], 21, 2);
+	}
+
+	/**
+	 * Only allow our custom blocks in editor, minus the ones listed in:
+	 * $this->blocksDisallowedByDefault().
+	 *
+	 * @param  bool|array<bool|string> $allowedBlocks Array of block type slugs, or boolean to enable/disable all.
+	 * @param WP_Block_Editor_Context $blockEditorContext The post resource data.
+	 *
+	 * @return bool|array<bool|string>
+	 */
+	public function allowOnlyCustomBlocks($allowedBlocks, WP_Block_Editor_Context $blockEditorContext)
+	{
+		// If all blocks are allowed, $allowedBlocks will be === true. If this is the case, we only
+		// wish to allow our custom blocks.
+		if (!\is_array($allowedBlocks)) {
+			$allowedBlocks = \array_merge(
+				(array) $this->getAllBlocksList([], $blockEditorContext),
+			);
+		}
+
+		// Don't allow blocks which are specific to MoviesPostType on other post types.
+		if ($blockEditorContext->post && $blockEditorContext->post->post_type !== MoviesPostType::POST_TYPE_SLUG) {
+			$allowedBlocks = $this->unsetBlocks($allowedBlocks, $this->moviesCptOnlyBlocks());
+		}
+
+		return \is_array($allowedBlocks) ? \array_values($allowedBlocks) : $allowedBlocks;
+	}
+
+	/**
+	 * Removes blocks from $original array
+	 *
+	 * @param  array<bool|string>|bool $original Array of blocks.
+	 * @param array<bool> $toRemove Array of blocks to remove.
+	 *
+	 * @return array<bool|string>|bool
+	 */
+	protected function unsetBlocks($original, array $toRemove)
+	{
+		if (!\is_array($original)) {
+			return $original;
+		}
+
+		return \array_values(\array_filter($original, function ($blockName) use ($toRemove) {
+			return !isset($toRemove[$blockName]);
+		}));
+	}
+
+	/**
+	 * Blocks which are only registered in Movies CPT.
+	 *
+	 * @return array<string, bool>
+	 */
+	protected function moviesCptOnlyBlocks(): array
+	{
+		return [
+			'eightshift-boilerplate/quote' => true,
+		];
 	}
 }

--- a/wp-content/themes/movies/src/Blocks/assets/styles/editor/_editor.scss
+++ b/wp-content/themes/movies/src/Blocks/assets/styles/editor/_editor.scss
@@ -9,7 +9,11 @@ body .editor-styles-wrapper {
 	@include font-smoothing;
 	font-family: var(--global-font-family);
 	color: var(--global-colors-black);
-	background-color: var(--global-colors-white);
+	background-color: var(--global-colors-gray500);
+
+	@include media(desktop up) {
+		padding-inline: 10rem;
+	}
 }
 
 // Sets base font size value only to editor part.

--- a/wp-content/themes/movies/src/Blocks/components/paragraph/manifest.json
+++ b/wp-content/themes/movies/src/Blocks/components/paragraph/manifest.json
@@ -65,7 +65,9 @@
 			"white",
 			"black",
 			"primary500",
-			"navy"
+			"navy",
+			"gray100",
+			"gray300"
 		]
 	},
 	"variables": {
@@ -360,6 +362,22 @@
 				{
 					"variable": {
 						"paragraph-color": "var(--global-colors-navy)",
+						"paragraph-link-color": "var(--global-colors-primary700)"
+					}
+				}
+			],
+			"gray100": [
+				{
+					"variable": {
+						"paragraph-color": "var(--global-colors-gray100)",
+						"paragraph-link-color": "var(--global-colors-primary700)"
+					}
+				}
+			],
+			"gray300": [
+				{
+					"variable": {
+						"paragraph-color": "var(--global-colors-gray300)",
 						"paragraph-link-color": "var(--global-colors-primary700)"
 					}
 				}

--- a/wp-content/themes/movies/src/Blocks/custom/quote/components/quote-editor.js
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/components/quote-editor.js
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react';
+import { outputCssVariables, getUnique, props } from '@eightshift/frontend-libs/scripts';
+import { ParagraphEditor } from '../../../components/paragraph/components/paragraph-editor';
+import manifest from '../manifest.json';
+import globalManifest from '../../../manifest.json';
+
+export const QuoteEditor = ({ attributes, setAttributes }) => {
+	const unique = useMemo(() => getUnique(), []);
+
+	const {
+		blockClass
+	} = attributes;
+
+	return (
+		<>
+			{outputCssVariables(attributes, manifest, unique, globalManifest)}
+
+			<div className={blockClass} data-id={unique}>
+				<ParagraphEditor
+					{...props('paragraph', attributes, {
+						selectorClass: 'paragraph',
+						setAttributes,
+					})}
+				/>
+				<ParagraphEditor
+					{...props('movie', attributes, {
+						selectorClass: 'movie',
+						setAttributes,
+					})}
+				/>
+				<ParagraphEditor
+					{...props('author', attributes, {
+						selectorClass: 'author',
+						setAttributes,
+					})}
+				/>
+			</div>
+		</>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/quote/components/quote-options.js
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/components/quote-options.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+import { props } from '@eightshift/frontend-libs/scripts';
+import { ParagraphOptions } from '../../../components/paragraph/components/paragraph-options';
+
+export const QuoteOptions = ({ attributes, setAttributes }) => {
+	return (
+		<PanelBody title={__('Quote Details', 'productive')}>
+			<ParagraphOptions
+				{...props('paragraph', attributes)}
+				setAttributes={setAttributes}
+			/>
+			<ParagraphOptions
+				{...props('movie', attributes)}
+				setAttributes={setAttributes}
+			/>
+			<ParagraphOptions
+				{...props('author', attributes)}
+				setAttributes={setAttributes}
+			/>
+		</PanelBody>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/quote/manifest.json
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/manifest.json
@@ -1,0 +1,61 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"blockName": "quote",
+	"title": "Quote",
+	"description" : "Quote block with custom settings.",
+	"category": "eightshift",
+	"icon": {
+		"src": "format-quote"
+	},
+	"keywords": [
+		"quote"
+	],
+	"attributes": {
+		"wrapperSimple": {
+			"type": "boolean",
+			"default": true
+		},
+		"wrapperSpacingTopLarge": {
+			"type": "integer",
+			"default": 20
+		},
+		"wrapperSpacingBottomLarge": {
+			"type": "integer",
+			"default": 0
+		},
+		"quoteParagraphSize": {
+			"type": "string",
+			"default": "h6:medium"
+		},
+		"quoteParagraphColor": {
+			"type": "string",
+			"default": "white"
+		},
+		"quoteMovieColor": {
+			"type": "string",
+			"default": "gray100"
+		},
+		"quoteMovieSize": {
+			"type": "string",
+			"default": "body:bold"
+		},
+		"quoteAuthorColor": {
+			"type": "string",
+			"default": "gray300"
+		}
+	},
+	"components": {
+		"paragraph": "paragraph",
+		"movie": "paragraph",
+		"author": "paragraph"
+	},
+	"variables": {
+		"quoteParagraphColor": [
+			{
+				"variable": {
+					"quote-border-color": "var(--global-colors-%value%)"
+				}
+			}
+		]
+	}
+}

--- a/wp-content/themes/movies/src/Blocks/custom/quote/quote-block.js
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/quote-block.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { InspectorControls } from '@wordpress/block-editor';
+import { QuoteEditor } from './components/quote-editor';
+import { QuoteOptions } from './components/quote-options';
+
+export const Quote = (props) => {
+	return (
+		<>
+			<InspectorControls>
+				<QuoteOptions {...props} />
+			</InspectorControls>
+			<QuoteEditor {...props} />
+		</>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/quote/quote-style.scss
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/quote-style.scss
@@ -1,0 +1,15 @@
+.block-quote {
+	text-align: var(--quote-align);
+
+	border-left: 4px solid var(--quote-border-color);
+	padding-left: 2.5rem;
+
+	&__paragraph {
+		margin-bottom: 0.7rem;
+		font-style: italic;
+	}
+
+	&__movie {
+		margin-bottom: 0.2rem;
+	}
+}

--- a/wp-content/themes/movies/src/Blocks/custom/quote/quote.php
+++ b/wp-content/themes/movies/src/Blocks/custom/quote/quote.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Template for the Quote Block view.
+ *
+ * @package Movies
+ */
+
+use MoviesVendor\EightshiftLibs\Helpers\Components;
+
+$globalManifest = Components::getSettings();
+$manifest = Components::getManifest(__DIR__);
+$blockName = $attributes['blockName'] ?? $manifest['blockName'];
+
+$blockClasses = Components::classnames([
+	Components::checkAttr('blockClass', $attributes, $manifest),
+	$attributes['className'] ?? ''
+]);
+
+$unique = Components::getUnique();
+echo Components::outputCssVariables($attributes, $manifest, $unique);
+?>
+
+<div
+	class="<?php echo esc_attr($blockClasses); ?>"
+	data-id="<?php echo esc_attr($unique); ?>"
+>
+	<?php
+	echo Components::render(
+		'paragraph',
+		Components::props('paragraph', $attributes)
+	),
+	Components::render('paragraph', Components::props('movie', $attributes, [
+		'selectorClass' => 'movie',
+	])),
+	Components::render('paragraph', Components::props('author', $attributes, [
+		'selectorClass' => 'author',
+	]));
+	?>
+</div>


### PR DESCRIPTION
This PR will:

- create custom Gutenberg block called `Quote`
- block allows editor to enter movie quote, name of the movie and quote author
- block uses `paragraph` component and its options and allows adjusting style in the editor and block options
- block is restricted to `movies` CPT

Also, with this PR I am removing default WordPress blocks and limiting the blocks to just custom, to avoid confusion/duplicated blocks.