### PR TITLE
Add shortcode for listing movies

### DIFF
--- a/wp-content/themes/movies/archive-movie.php
+++ b/wp-content/themes/movies/archive-movie.php
@@ -7,9 +7,11 @@
  */
 
 get_header();
+
+$movieArchiveClass = 'archive-movie-template';
 ?>
 
-    <article class="archive-movie-template">
+    <article class="<?php echo esc_attr($movieArchiveClass); ?>">
 		<?php
 		if (have_posts()) {
 			while (have_posts()) {
@@ -17,13 +19,13 @@ get_header();
 
 				?>
 
-                <a href="<?php the_permalink(); ?>" class="archive-movie-template__card">
-                    <div class="archive-movie-template__card-image">
+                <a href="<?php the_permalink(); ?>" class="<?php echo esc_attr($movieArchiveClass); ?>__card">
+                    <div class="<?php echo esc_attr($movieArchiveClass); ?>__card-image">
                         <img src="<?php echo esc_url(get_the_post_thumbnail_url(get_the_ID(), 'large')); ?>"
                              alt="<?php echo esc_attr(get_the_title()); ?>">
                     </div>
-                    <h2 class="archive-movie-template__card-title"><?php the_title(); ?></h2>
-                    <div class="archive-movie-template__card-content">
+                    <h2 class="<?php echo esc_attr($movieArchiveClass); ?>__card-title"><?php echo esc_attr(get_the_title()); ?></h2>
+                    <div class="<?php echo esc_attr($movieArchiveClass); ?>__card-content">
 						<?php the_content(); ?>
                     </div>
                 </a>

--- a/wp-content/themes/movies/src/Blocks/Blocks.php
+++ b/wp-content/themes/movies/src/Blocks/Blocks.php
@@ -72,6 +72,8 @@ class Blocks extends AbstractBlocks
 			);
 		}
 
+		$allowedBlocks[] = 'core/shortcode';
+
 		// Don't allow blocks which are specific to MoviesPostType on other post types.
 		if ($blockEditorContext->post && $blockEditorContext->post->post_type !== MoviesPostType::POST_TYPE_SLUG) {
 			$allowedBlocks = $this->unsetBlocks($allowedBlocks, $this->moviesCptOnlyBlocks());

--- a/wp-content/themes/movies/src/Shortcode/DisplayMovies.php
+++ b/wp-content/themes/movies/src/Shortcode/DisplayMovies.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * The file that defines the MoviesShortcode class.
+ *
+ * @package Movies\Shortcode;
+ */
+
+declare(strict_types=1);
+
+namespace Movies\Shortcode;
+
+use MoviesVendor\EightshiftLibs\Services\ServiceInterface;
+use WP_Query;
+
+/**
+ * MoviesShortcode class.
+ */
+class DisplayMovies implements ServiceInterface
+{
+	/**
+	 * Register all the hooks
+	 *
+	 * @return void
+	 */
+	public function register(): void
+	{
+		\add_shortcode('movies_list', [$this, 'renderMoviesShortcode']);
+	}
+
+	/**
+	 * Render the movies list shortcode
+	 *
+	 * @param array<string, mixed> $atts Shortcode attributes.
+	 *
+	 * @return string
+	 */
+	public function renderMoviesShortcode($atts): string
+	{
+		$movieArchiveClass = 'archive-movie-template';
+
+		// Parse shortcode attributes with defaults.
+		$atts = \shortcode_atts(
+			[
+				'genre' => '', // Default to no genre filter.
+				'number' => 100, // Default number of movies to display.
+			],
+			$atts,
+			'movies_list'
+		);
+
+		// Query arguments.
+		$args = [
+			'post_type' => 'movie',
+			'posts_per_page' => (int) $atts['number'],
+			'tax_query' => [],
+		];
+
+		// Add taxonomy filter if 'genre' is provided.
+		if (!empty($atts['genre'])) {
+			$args['tax_query'][] = [
+				'taxonomy' => 'genre',
+				'field'    => 'slug',
+				'terms'    => $atts['genre'],
+			];
+		}
+
+		// Query movies.
+		$query = new WP_Query($args);
+
+		// Start output buffering.
+		\ob_start();
+
+		if (!$query->have_posts()) {
+			echo '<p class="movie-list__empty">No movies found.</p>';
+		} else { ?>
+		<article class="<?php echo \esc_attr($movieArchiveClass); ?>">
+			<?php
+			while ($query->have_posts()) {
+					$query->the_post(); ?>
+
+				<a href="<?php echo \esc_url(\get_permalink()); ?>" class="<?php echo \esc_attr($movieArchiveClass); ?>__card">
+					<div class="<?php echo \esc_attr($movieArchiveClass); ?>__card-image">
+						<img src="<?php echo \esc_url(\get_the_post_thumbnail_url(\get_the_ID(), 'large')); ?>"
+							 alt="<?php echo \esc_attr(\get_the_title()); ?>">
+					</div>
+					<h2 class="<?php echo \esc_attr($movieArchiveClass); ?>__card-title"><?php echo \esc_attr(\get_the_title()); ?></h2>
+				</a>
+
+			<?php } ?>
+		</article>
+			<?php
+		}
+
+		// Reset post data.
+		\wp_reset_postdata();
+
+		// Return the output.
+		return \ob_get_clean();
+	}
+}


### PR DESCRIPTION
This PR will:

- register new shortcode that can be used for listing movies CPT and use attributes like genre or number
- allow `core/shortcode` block in the editor
- smaller adjustments to coding standards