### PR TITLE
Create Carousel block

### DIFF
--- a/wp-content/themes/movies/package-lock.json
+++ b/wp-content/themes/movies/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@eightshift/frontend-libs": "^9.0.0"
+				"@eightshift/frontend-libs": "^9.0.0",
+				"swiper": "^11.1.15"
 			},
 			"devDependencies": {
 				"husky": "^8.0.3",
@@ -18266,6 +18267,25 @@
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
 			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
 			"license": "CC0-1.0"
+		},
+		"node_modules/swiper": {
+			"version": "11.1.15",
+			"resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.15.tgz",
+			"integrity": "sha512-IzWeU34WwC7gbhjKsjkImTuCRf+lRbO6cnxMGs88iVNKDwV+xQpBCJxZ4bNH6gSrIbbyVJ1kuGzo3JTtz//CBw==",
+			"funding": [
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/swiperjs"
+				},
+				{
+					"type": "open_collective",
+					"url": "http://opencollective.com/swiper"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.7.0"
+			}
 		},
 		"node_modules/synchronous-promise": {
 			"version": "2.0.17",

--- a/wp-content/themes/movies/package.json
+++ b/wp-content/themes/movies/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@eightshift/Movies",
 	"version": "1.0.0",
-
 	"description": "This is a repository for test Movies website showcasing WP dev features.",
 	"authors": [
 		{
@@ -34,7 +33,8 @@
 		"webpack-cli": "^5.0.1"
 	},
 	"dependencies": {
-		"@eightshift/frontend-libs": "^9.0.0"
+		"@eightshift/frontend-libs": "^9.0.0",
+		"swiper": "^11.1.15"
 	},
 	"husky": {
 		"hooks": {

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/assets/carousel-slider.js
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/assets/carousel-slider.js
@@ -1,0 +1,50 @@
+import Swiper from 'swiper';
+import { Navigation, Pagination } from 'swiper/modules';
+
+export class CarouselSlider {
+	constructor(options) {
+		this.element = options.element;
+		this.blockClass = options.blockClass;
+		this.nextElement = options.nextElement;
+		this.prevElement = options.prevElement;
+		this.paginationElement = options.paginationElement;
+		this.eventName = options.eventName;
+
+	}
+
+	init() {
+		const item = this.element;
+
+		new Swiper(item, {
+			loop: item.getAttribute('data-swiper-loop') ?? false,
+			loopedSlides: 6,
+			slideClass: `${this.blockClass}__item`,
+			slidesPerView: 'auto',
+			watchOverflow: true,
+			modules: [
+				Navigation,
+				Pagination,
+			],
+			keyboard: {
+				enabled: true,
+			},
+			grabCursor: true,
+			breakpointsInverse: true,
+			threshold: 20,
+			navigation: {
+				nextEl: this.nextElement,
+				prevEl: this.prevElement,
+			},
+			pagination: {
+				el: this.paginationElement,
+				type: 'bullets',
+				clickable: true,
+			},
+			on: {
+				init: () => {
+					window.dispatchEvent(this.eventName);
+				},
+			},
+		});
+	}
+}

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/assets/index.js
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/assets/index.js
@@ -1,0 +1,26 @@
+import domReady from '@wordpress/dom-ready';
+
+domReady(async () => {
+	const selector = '.js-block-carousel';
+	const elements = document.querySelectorAll(selector);
+
+	if (!elements.length) {
+		return;
+	}
+
+	const eventName = new CustomEvent('carouselInit');
+	const { CarouselSlider } = await import('./carousel-slider');
+
+	[...elements].forEach((element) => {
+		const carouselSlider = new CarouselSlider({
+			element,
+			blockClass: 'block-carousel',
+			nextElement: `${selector}-next`,
+			prevElement: `${selector}-prev`,
+			paginationElement: `${selector}-pagination`,
+			eventName,
+		});
+
+		carouselSlider.init();
+	});
+});

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-block.js
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-block.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useSelect } from '@wordpress/data';
+import { overrideInnerBlockAttributes } from '@eightshift/frontend-libs/scripts';
+import { InspectorControls } from '@wordpress/block-editor';
+import { CarouselOptions } from './components/carousel-options';
+import { CarouselEditor } from './components/carousel-editor';
+
+export const Carousel = (props) => {
+	const {
+		clientId,
+		attributes: {
+			blockClass,
+		},
+	} = props;
+
+	// Set this attributes to all inner blocks once inserted in DOM.
+	useSelect((select) => {
+		overrideInnerBlockAttributes(
+			select,
+			clientId,
+			{
+				wrapperDisable: true,
+				wrapperUse: false,
+				wrapperParentClass: blockClass,
+			}
+		);
+	});
+
+	return (
+		<>
+			<InspectorControls>
+				<CarouselOptions {...props} />
+			</InspectorControls>
+			<CarouselEditor {...props} />
+		</>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-editor.scss
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-editor.scss
@@ -1,0 +1,15 @@
+.block-carousel {
+	.block-editor-block-list {
+		&__layout {
+			display: flex;
+			align-items: flex-start;
+			gap: 1rem;
+			width: 100%;
+			overflow-x: scroll;
+		}
+
+		&__block {
+			min-width: 25%;
+		}
+	}
+}

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-style.scss
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/carousel-style.scss
@@ -1,0 +1,87 @@
+@import '~swiper/css';
+
+.block-carousel {
+	width: 100%;
+
+	&__item {
+		flex-shrink: 0;
+		transition-property: transform;
+		display: flex;
+
+		max-width: 10rem;
+
+		@include media(tablet up) {
+			max-width: 15rem;
+		}
+
+		@include media(desktop up) {
+			max-width: 20rem;
+		}
+	}
+
+	&__item-inner {
+		display: flex;
+		align-items: center;
+		max-width: 100%;
+	}
+
+	&__top-bar {
+		display: grid;
+		grid-template-columns: var(--wrapper-grid-side-columns) 1fr auto auto var(--wrapper-grid-side-columns);
+		grid-template-rows: auto;
+		grid-template-areas: '. heading prev next .';
+		column-gap: var(--global-grid-gutter);
+
+		padding-top: 4rem;
+		padding-bottom: 2rem;
+
+		@include media(large up) {
+			grid-template-columns: 1fr auto auto var(--wrapper-grid-side-columns);
+			grid-template-areas: 'heading prev next .';
+		}
+	}
+
+	&__heading {
+		grid-area: heading;
+	}
+
+	&__prev-button,
+	&__next-button {
+		grid-area: next;
+		border: 1px solid var(--global-colors-white);
+		border-radius: 50%;
+		padding: 1rem;
+		cursor: pointer;
+		transition: background-color 0.3s, color 0.3s;
+
+		&:hover,
+		&:focus {
+			background-color: var(--global-colors-white);
+			color: var(--global-colors-black);
+		}
+	}
+
+	&__prev-button {
+		grid-area: prev;
+	}
+
+	&__next-button {
+		grid-area: next;
+	}
+
+	& .swiper-wrapper > * {
+		margin-left: var(--global-grid-gutter);
+
+		&:first-child {
+			margin-left: var(--global-grid-side-padding);
+
+			@include media(large up) {
+				margin-left: 0;
+			}
+		}
+
+		&:last-child {
+			margin-right: var(--global-grid-side-padding);
+		}
+	}
+}

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/carousel.php
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/carousel.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Template for the Carousel Block.
+ *
+ * @package Movies
+ */
+
+use MoviesVendor\EightshiftLibs\Helpers\Components;
+
+$manifest = Components::getManifest(__DIR__);
+
+$blockClass = $attributes['blockClass'] ?? '';
+$blockJsClass = $attributes['blockJsClass'] ?? '';
+
+$carouselIsLoop = Components::checkAttr('carouselIsLoop', $attributes, $manifest);
+
+$carouselClass = Components::classnames([
+	$blockClass,
+	$blockJsClass,
+	'swiper',
+	$attributes['className'] ?? ''
+]);
+
+$carouselTopBarClass = Components::selector($blockClass, $blockClass, 'top-bar');
+
+?>
+
+
+<div
+	class="<?php echo esc_attr($carouselClass); ?>"
+	data-swiper-loop="<?php echo esc_attr($carouselIsLoop); ?>"
+>
+
+    <div class="<?php echo esc_attr($carouselTopBarClass); ?>">
+		<?php
+		echo Components::render(
+			'heading',
+			array_merge(
+				Components::props('heading', $attributes),
+				[]
+			)
+		),
+		Components::render(
+			'icon',
+			Components::props('icon', $attributes, [
+				'iconName' => 'arrow-chevron-back',
+				'selectorClass' => 'prev-button',
+				'additionalClass' => "{$blockJsClass}-prev"
+			])
+		),
+		Components::render(
+			'icon',
+			Components::props('icon', $attributes, [
+				'iconName' => 'arrow-chevron-forward',
+				'selectorClass' => 'next-button',
+				'additionalClass' => "{$blockJsClass}-next"
+			])
+		);
+		?>
+    </div>
+
+	<div class="<?php echo esc_attr('swiper-wrapper'); ?>">
+		<?php echo $innerBlockContent; // phpcs:ignore Eightshift.Security.ComponentsEscape.OutputNotEscaped ?>
+	</div>
+</div>

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/components/carousel-editor.js
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/components/carousel-editor.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { InnerBlocks } from '@wordpress/block-editor';
+import { checkAttr, selector, props, classnames } from '@eightshift/frontend-libs/scripts';
+import { HeadingEditor } from '../../../components/heading/components/heading-editor';
+import { IconEditor } from '../../../components/icon/components/icon-editor';
+import manifest from '../manifest.json';
+
+export const CarouselEditor = ({ attributes, setAttributes }) => {
+	const {
+		blockClass,
+		blockJsClass,
+	} = attributes;
+
+	const carouselAllowedBlocks = checkAttr('carouselAllowedBlocks', attributes, manifest);
+	const carouselIsLoop = checkAttr('carouselIsLoop', attributes, manifest);
+
+	const carouselClass = classnames(
+		blockClass,
+		blockJsClass,
+	);
+
+	const carouselTopBarClass = selector(blockClass, blockClass, 'top-bar');
+
+	return (
+		<div
+			className={carouselClass}
+			data-is-loop={carouselIsLoop}
+		>
+			<div className={carouselTopBarClass}>
+				<HeadingEditor
+					{...props('heading', attributes)}
+					setAttributes={setAttributes}
+				/>
+
+				<IconEditor
+					{...props('chevron', attributes, {
+						iconName: 'arrow-chevron-back',
+						selectorClass: 'prev-button'
+					})}
+					setAttributes={setAttributes}
+				/>
+
+				<IconEditor
+					{...props('chevron', attributes, {
+						iconName: 'arrow-chevron-forward',
+						selectorClass: 'next-button'
+					})}
+					setAttributes={setAttributes}
+				/>
+			</div>
+
+			<InnerBlocks
+				orientation={'horizontal'}
+				allowedBlocks={carouselAllowedBlocks}
+			/>
+		</div>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/components/carousel-options.js
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/components/carousel-options.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { props, checkAttr, getAttrKey } from '@eightshift/frontend-libs/scripts';
+import { HeadingOptions } from '../../../components/heading/components/heading-options';
+import manifest from './../manifest.json';
+
+export const CarouselOptions = ({ attributes, setAttributes }) => {
+	const {
+		showCarouselLoop = true
+	} = attributes;
+
+	const carouselIsLoop = checkAttr('carouselIsLoop', attributes, manifest);
+	
+	return (
+		<PanelBody title={__('Carousel Details', 'productive')}>
+			{showCarouselLoop &&
+				<>
+					<div className='es-icon-toggle es-icon-toggle--reverse'>
+						<ToggleControl
+							label={__('Loop mode', 'productive')}
+							help={__('Allows infinite scrolling', 'productive')}
+							checked={carouselIsLoop}
+							onChange={(value) => setAttributes({ [getAttrKey('carouselIsLoop', attributes, manifest)]: value })}
+						/>
+					</div>
+				</>
+			}
+
+			<HeadingOptions
+				{...props('heading', attributes)}
+				setAttributes={setAttributes}
+			/>
+		</PanelBody>
+	);
+};

--- a/wp-content/themes/movies/src/Blocks/custom/carousel/manifest.json
+++ b/wp-content/themes/movies/src/Blocks/custom/carousel/manifest.json
@@ -1,0 +1,64 @@
+{
+	"$schema": "https://raw.githubusercontent.com/infinum/eightshift-frontend-libs/develop/schemas/block.json",
+	"blockName": "carousel",
+	"title": "Carousel",
+	"description" : "Carousel block with custom settings.",
+	"category": "eightshift",
+	"icon": {
+		"src": "es-carousel"
+	},
+	"keywords": [
+		"carousel"
+	],
+	"hasInnerBlocks": true,
+	"attributes": {
+		"carouselAllowedBlocks": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			},
+			"default": [
+				"eightshift-boilerplate/image"
+			]
+		},
+		"carouselIsLoop": {
+			"type": "boolean",
+			"default": true
+		},
+		"carouselShowItems": {
+			"type": "number",
+			"default": 1
+		},
+		"wrapperSimple": {
+			"type": "boolean",
+			"default": true
+		},
+	  	"wrapperIsFullWidthLarge": {
+		  	"type": "boolean",
+		  	"default": true
+		},
+	  	"wrapperWidthLarge": {
+		  	"type": "integer",
+		  	"default": 14
+		},
+		"wrapperWidthMobile": {
+		  "type": "integer",
+		  "default": 14
+		},
+		"carouselHeadingSize": {
+			"type": "string",
+			"default": "h5:bold"
+		}
+	},
+	"options": {
+		"carouselItemsToShow": {
+			"min": 1,
+			"max": 2,
+			"step": 1
+		}
+	},
+	"components": {
+		"icon": "icon",
+		"heading": "heading"
+	}
+}


### PR DESCRIPTION
This PR will:

- create simple `Carousel` Gutenberg block that can be used in the editor
- block uses `swiper.js` library
- block is responsive and there can be multiple instances of the block on the same page
- block has option to choose whether it's in `Loop mode` or not